### PR TITLE
Run clean before publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,6 @@ test:
 clean:
 	rm -rf build/ dist/ httpie_asap_auth.egg-info/
 
-publish:
+publish: clean
 	python setup.py sdist
 	twine upload dist/*


### PR DESCRIPTION
Otherwise artifacts from a bdist build (eg. httpie-asap-auth-0.0.8.macosx-10.13-x86_64.tar.gz) may be uploaded.