### PR TITLE
Changed the package import name to reflect changes in httpie

### DIFF
--- a/httpie_asap_auth.py
+++ b/httpie_asap_auth.py
@@ -12,7 +12,7 @@ import atlassian_jwt_auth.key
 import atlassian_jwt_auth.signer
 import atlassian_jwt_auth.contrib.requests
 
-from httpie import ExitStatus
+from httpie.status import ExitStatus
 from httpie.plugins import AuthPlugin
 
 


### PR DESCRIPTION
The current plugin throws an import error upon installing against the homebrew python (version 3.8). This is because the package structure in httpie has changed to include `ExitStatus` in `httpie.status`. This is a small change to fix this error.